### PR TITLE
Add a temporary shim to bridge Go 1.23 and Go 1.24

### DIFF
--- a/gocache.go
+++ b/gocache.go
@@ -227,7 +227,8 @@ func (s *Server) handleRequest(ctx context.Context, req *progRequest) (pr *progR
 		}
 		return s.handleGet(ctx, req)
 	case "put":
-		s.vlogf("bc B PUT R:%d, A:%x, O:%x, S:%d", req.ID, req.ActionID, req.OutputID, req.BodySize)
+		outputID := req.outputID()
+		s.vlogf("bc B PUT R:%d, A:%x, O:%x, S:%d", req.ID, req.ActionID, outputID, req.BodySize)
 		defer func() {
 			if oerr != nil {
 				s.putErrors.Add(1)
@@ -236,7 +237,7 @@ func (s *Server) handleRequest(ctx context.Context, req *progRequest) (pr *progR
 				req.ID, oerr, time.Since(start), value.At(pr).DiskPath)
 		}()
 		s.putRequests.Add(1)
-		if len(req.ActionID) == 0 || len(req.OutputID) == 0 {
+		if len(req.ActionID) == 0 || len(outputID) == 0 {
 			// This should not be possible with a real toolchain, but defend
 			// against weird input from a human testing things.
 			return nil, errors.New("put: invalid ActionID/OutputID")

--- a/internal_test.go
+++ b/internal_test.go
@@ -141,6 +141,13 @@ func TestServer(t *testing.T) {
 			{send: &progRequest{ID: 5, Command: "put"}}, // invalid: no action/object ID
 			{send: &progRequest{ID: 6, Command: "get"}}, // invalid: no action ID
 			{wait: true},
+			{send: &progRequest{ID: 7, Command: "put",
+				ActionID:    []byte("\x04"),
+				OldOutputID: []byte("\x0b\x1e\xc7"),
+				BodySize:    5,
+				Body:        strings.NewReader("apple"),
+			}},
+			{wait: true},
 			{wait: true},
 			{send: &progRequest{ID: 999, Command: "close"}},
 			{wait: true},
@@ -201,6 +208,7 @@ func TestServer(t *testing.T) {
 		4:   {ID: 4, DiskPath: objPath},
 		5:   {ID: 5, Err: "put: invalid ActionID/OutputID"},
 		6:   {ID: 6, Err: "get: invalid ActionID"},
+		7:   {ID: 7, DiskPath: objPath},
 		999: {ID: 999}, // close response
 	}); diff != "" {
 		t.Errorf("Responses (-got, +want):\n%s", diff)

--- a/types.go
+++ b/types.go
@@ -23,9 +23,14 @@ type progRequest struct {
 	ActionID []byte `json:",omitempty"` // or nil if not used
 
 	// OutputID is set for Type "put" and "output-file".
+	OutputID []byte `json:"OutputID,omitempty"` // or nil if not used
+
+	// OldOutputID is a workaround for the rename of "ObjectID" to "OutputID"
+	// between Go 1.23 and Go 1.24. Do not use this field, it will be removed.
 	//
-	// TODO(creachadair): Remove the name override once the default changes.
-	OutputID []byte `json:"ObjectID,omitempty"` // or nil if not used
+	// TODO(creachadair): Remove after Go 1.24 is released with cacheprog as a
+	// non-experimental feature.
+	OldOutputID []byte `json:"ObjectID,omitempty"`
 
 	// Body is the body for "put" requests. It's sent after the JSON object
 	// as a base64-encoded JSON string when BodySize is non-zero.
@@ -37,6 +42,15 @@ type progRequest struct {
 
 	// BodySize is the number of bytes of Body. If zero, the body isn't written.
 	BodySize int64 `json:",omitempty"`
+}
+
+// outputID returns the output ID from r, preferring OutputID if it is present,
+// and otherwise falling back to OldOutputID..
+func (r *progRequest) outputID() []byte {
+	if len(r.OutputID) != 0 {
+		return r.OutputID
+	}
+	return r.OldOutputID
 }
 
 // progResponse is a JSON encoded response to the client.


### PR DESCRIPTION
Prior to Go 1.24, the cacheprog request message used "ObjectID" in its "put"
request message to the plugin. For the non-experiment release in Go 1.24, it is
being changed to "OutputID" to match the response message.

As a workaround in the meantime, make the server handle both names, preferring
the newer one. The real toolchain will never set both, so this should be fine.
