### PR TITLE
gocache: use new outputID() bridge for filename

### DIFF
--- a/gocache.go
+++ b/gocache.go
@@ -309,7 +309,7 @@ func (s *Server) handlePut(ctx context.Context, req *progRequest) (pr *progRespo
 
 	diskPath, err := s.Put(ctx, Object{
 		ActionID: fmt.Sprintf("%x", req.ActionID),
-		OutputID: fmt.Sprintf("%x", req.OutputID),
+		OutputID: fmt.Sprintf("%x", req.outputID()),
 		Size:     req.BodySize,
 		Body:     body,
 	})


### PR DESCRIPTION
Without this, creating filenames based on the OutputID fails (for me, in Go 1.23; on tip, this continues to work).