### PR TITLE
gocache: fix disk path naming

### DIFF
--- a/gocache.go
+++ b/gocache.go
@@ -309,7 +309,7 @@ func (s *Server) handlePut(ctx context.Context, req *progRequest) (pr *progRespo
 
 	diskPath, err := s.Put(ctx, Object{
 		ActionID: fmt.Sprintf("%x", req.ActionID),
-		OutputID: fmt.Sprintf("%x", req.OutputID),
+		OutputID: fmt.Sprintf("%x", req.outputID()),
 		Size:     req.BodySize,
 		Body:     body,
 	})

--- a/internal_test.go
+++ b/internal_test.go
@@ -30,8 +30,9 @@ func TestServer(t *testing.T) {
 	// Create an output file for a test object, so that the server plumbing can
 	// successfully find it when it's reported back.
 	// Note we set the modification time here so that the output will be stable.
+	dir := t.TempDir()
 	objTime := time.Date(2024, 8, 17, 14, 42, 45, 0, time.UTC)
-	objPath := filepath.Join(t.TempDir(), testObject)
+	objPath := filepath.Join(dir, testObject)
 	if err := os.WriteFile(objPath, []byte("xyzzy"), 0600); err != nil {
 		t.Fatalf("Create test object: %v", err)
 	}
@@ -69,7 +70,7 @@ func TestServer(t *testing.T) {
 		},
 		Put: func(ctx context.Context, obj Object) (diskPath string, _ error) {
 			checkContext(ctx)
-			return objPath, nil
+			return filepath.Join(dir, obj.OutputID), nil
 		},
 		Close: func(ctx context.Context) error {
 			checkContext(ctx)


### PR DESCRIPTION
In #1 Iadded an accessor for the request output ID, but I neglected to use it
when generating the output ID for "put" requests. Fix that, and update the test
to cover that case.

Co-Authored-By: Kevin Burke <kevin.burke@segment.com>
