### PR TITLE
Fix missing OutputID in GET responses.

### DIFF
--- a/gocache.go
+++ b/gocache.go
@@ -274,7 +274,9 @@ func (s *Server) handleGet(ctx context.Context, req *progRequest) (pr *progRespo
 	// Safety check: The output ID should be hex-encoded and non-empty.
 	if outputID == "" {
 		return nil, errors.New("get: empty output ID")
-	} else if _, err := hex.DecodeString(outputID); err != nil {
+	}
+	outputHexID, err := hex.DecodeString(outputID)
+	if err != nil {
 		return nil, fmt.Errorf("get: invalid object ID: %w", err)
 	}
 
@@ -295,7 +297,7 @@ func (s *Server) handleGet(ctx context.Context, req *progRequest) (pr *progRespo
 	s.getHits.Add(1)
 	s.getHitBytes.Add(fi.Size())
 	added := fi.ModTime().UTC()
-	return &progResponse{Size: fi.Size(), Time: &added, DiskPath: diskPath}, nil
+	return &progResponse{Size: fi.Size(), Time: &added, DiskPath: diskPath, OutputID: outputHexID}, nil
 }
 
 // handlePut handles "put" requests.

--- a/internal_test.go
+++ b/internal_test.go
@@ -204,7 +204,7 @@ func TestServer(t *testing.T) {
 
 	// Check that we got the desired responses.
 	if diff := gocmp.Diff(rsps, map[int64]*progResponse{
-		2:   {ID: 2, Size: 5, Time: &objTime, DiskPath: objPath},
+		2:   {ID: 2, Size: 5, Time: &objTime, DiskPath: objPath, OutputID: []byte("\x0b\x1e\xc7")},
 		3:   {ID: 3, Err: "get 99: erroneous condition"},
 		4:   {ID: 4, DiskPath: objPath},
 		5:   {ID: 5, Err: "put: invalid ActionID/OutputID"},


### PR DESCRIPTION
Gocacheprog expects Response.OutputID to be set in Get requests. While this does not seem to be useful in practice when the cache is used for build objects, it is checked for test objects. This prevented to cache tests execution.