### PR TITLE
Reject cache objects with unexpected sizes

### DIFF
--- a/cachedir/cachedir.go
+++ b/cachedir/cachedir.go
@@ -252,7 +252,17 @@ func (d *Dir) writeObject(obj gocache.Object) (string, int64, error) {
 		return path, fi.Size(), nil
 	}
 
-	sz, err := atomicfile.WriteAll(path, obj.Body, 0644)
+	var sz int64
+	err = atomicfile.Tx(path, 0644, func(w io.Writer) error {
+		var err error
+		sz, err = io.Copy(w, obj.Body)
+		if err != nil {
+			return err
+		} else if sz != obj.Size {
+			return fmt.Errorf("object size is %d bytes, want %d", sz, obj.Size)
+		}
+		return nil
+	})
 	if err == nil && !obj.ModTime.IsZero() {
 		os.Chtimes(path, time.Time{} /* atime: ignore */, obj.ModTime) // best-effort
 	}

--- a/cachedir/cachedir_test.go
+++ b/cachedir/cachedir_test.go
@@ -41,6 +41,20 @@ func TestDir(t *testing.T) {
 		t.Errorf(`Get(bogus-action): got %q, %q, nil; want "", "", <error>`, obj, path)
 	}
 
+	// A short object is rejected without committing its contents.
+	if _, err := d.Put(ctx, gocache.Object{
+		ActionID: "short-action",
+		OutputID: "short-object",
+		Size:     5,
+		Body:     strings.NewReader("bad"),
+	}); err == nil {
+		t.Error("Put(short-action): got nil, want error")
+	}
+	checkMiss("short-action")
+	if _, err := os.Stat(filepath.Join(dir, "output", "sh", "short-object")); !os.IsNotExist(err) {
+		t.Errorf("Short object should not exist, err=%v", err)
+	}
+
 	// Put a real object successfully.
 	testTime := time.Date(2024, 8, 25, 12, 46, 50, 0, time.Local)
 	diskPath, err := d.Put(ctx, gocache.Object{


### PR DESCRIPTION
Validate an object's copied size against its declared size before committing it to the cache directory.

I found this while investigating a corrupted entry served by our remote Go build cache in CI, which uses https://github.com/tailscale/go-cache-plugin. The S3 objects I sampled were intact, so I traced possible corruption paths
through the plugin's runner-local staging layer.

One path exposed by that investigation is a short read while downloading an object from S3 into the local cache after a local cache miss. The response supplies an expected content length, but its body can end before that many bytes have been read.

Previously, `writeObject` passed the body to `atomicfile.WriteAll` and recorded the number of bytes it actually wrote. A short body ending with a clean EOF was therefore committed successfully, and the action recorded that shorter size.
The resulting object and action agreed with each other, so a later `Get` returned the truncated file as a valid cache hit.

This is related to https://github.com/creachadair/atomicfile/pull/1, which handles explicit read and finalization errors in `WriteAll`. A clean EOF is not an error at that layer, however; `cachedir` is where the expected object size is known.

Use `atomicfile.Tx` directly so the copied size can be checked before the temporary file is renamed. A mismatch returns an error, cancels the transaction, and prevents the action from being recorded.